### PR TITLE
Add missing dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "test": "node_modules/.bin/eslint index.js && node_modules/.bin/mocha"
   },
   "dependencies": {
+    "lodash": "^4.17.4",
+    "mkdirp": "^0.5.1",
+    "progeny": "^0.11.0"
   },
   "devDependencies": {
     "chai": "~3.4.1",


### PR DESCRIPTION
Couldn't use this package because dependencies were missing in the
package.json: lodash, mkdirp, progeny

This PR simply adds those dependency declarations to the package.json