### PR TITLE
Update mocha dependency to ^3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "chai": "~3.4.1",
     "eslint": "^1.10.3",
-    "mocha": "~2.3.4"
+    "mocha": "^3.2.0"
   }
 }


### PR DESCRIPTION
This eliminates a warning generated from Mocha 2.3.4's dependency on
Jade that reminded us all that Jade has been renamed to Pug.